### PR TITLE
Made extend_to(const mini::string_ref) work

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -116,7 +116,7 @@ class tor_client
 
       if (router)
       {
-        extend_to(onion_router_name);
+        extend_to(router);
       }
     }
 


### PR DESCRIPTION
The unpatched extend_to() called itself again with the original parameter, creating an endless recursion.